### PR TITLE
winePackages.*: Enable wayland driver for all; wine-wayland: only add wayland prefix when needed

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -3,6 +3,7 @@
   bison, flex, fontforge, makeWrapper, pkg-config,
   nixosTests,
   supportFlags,
+  wineRelease,
   patches,
   moltenvk,
   buildScript ? null, configureFlags ? [], mainProgram ? "wine"
@@ -46,7 +47,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
 }) // rec {
   inherit version src;
 
-  pname = prevName + lib.optionalString supportFlags.waylandSupport "-wayland";
+  pname = prevName + lib.optionalString (wineRelease == "wayland") "-wayland";
 
   # Fixes "Compiler cannot create executables" building wineWow with mingwSupport
   strictDeps = true;

--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -36,7 +36,7 @@
   sdlSupport ? false,
   usbSupport ? false,
   mingwSupport ? wineRelease != "stable",
-  waylandSupport ? wineRelease == "wayland",
+  waylandSupport ? stdenv.isLinux,
   x11Support ? stdenv.isLinux,
   embedInstallers ? false, # The Mono and Gecko MSI installers
   moltenvk ? darwin.moltenvk # Allow users to override MoltenVK easily

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -8,7 +8,7 @@ let
 in with src; {
   wine32 = pkgsi686Linux.callPackage ./base.nix {
     pname = "wine";
-    inherit src version supportFlags patches moltenvk;
+    inherit src version supportFlags patches moltenvk wineRelease;
     pkgArches = [ pkgsi686Linux ];
     geckos = [ gecko32 ];
     mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc ];
@@ -17,7 +17,7 @@ in with src; {
   };
   wine64 = callPackage ./base.nix {
     pname = "wine64";
-    inherit src version supportFlags patches moltenvk;
+    inherit src version supportFlags patches moltenvk wineRelease;
     pkgArches = [ pkgs ];
     mingwGccs = with pkgsCross; [ mingwW64.buildPackages.gcc ];
     geckos = [ gecko64 ];
@@ -28,7 +28,7 @@ in with src; {
   };
   wineWow = callPackage ./base.nix {
     pname = "wine-wow";
-    inherit src version supportFlags patches moltenvk;
+    inherit src version supportFlags patches moltenvk wineRelease;
     stdenv = stdenv_32bit;
     pkgArches = [ pkgs pkgsi686Linux ];
     geckos = [ gecko32 gecko64 ];
@@ -44,7 +44,7 @@ in with src; {
   };
   wineWow64 = callPackage ./base.nix {
     pname = "wine-wow64";
-    inherit src version patches moltenvk;
+    inherit src version patches moltenvk wineRelease;
     supportFlags = supportFlags // { mingwSupport = true; };  # Required because we request "--enable-archs=x86_64"
     pkgArches = [ pkgs ];
     mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc mingwW64.buildPackages.gcc ];


### PR DESCRIPTION
This is how wayland driver can be enabled for all, keeping the flag same as x11Support while only adding the -wayland prefix on the forked version. Since i can't add commits to that PR, i though i could make one here